### PR TITLE
#22 Add isContrasting method

### DIFF
--- a/Sources/DynamicColor.swift
+++ b/Sources/DynamicColor.swift
@@ -191,6 +191,65 @@ public extension DynamicColor {
     let l2 = min(selfLuminance, otherLuminance)
         
     return (l1+0.05)/(l2+0.05)
-       
+  }
+  
+  /**
+   Used to describe the context of display of 2 colors.
+   Based on WCAG: https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-contrast
+  */
+  enum ContrastDisplayContext {
+    /**
+      A standard text in a normal context
+     */
+    case Standard
+    /** 
+     A large text in a normal context.
+     You can look here for the definition of "large text":
+      https://www.w3.org/TR/2008/REC-WCAG20-20081211/#larger-scaledef
+     */
+    case StandardLargeText
+    /**
+     A standard text in an enhanced context.
+     Enhanced means that you want to be accessible (and AAA compliant in WCAG)
+     */
+    case Enhanced
+    /**
+     A large text in an enhanced context.
+     Enhanced means that you want to be accessible (and AAA compliant in WCAG)
+     You can look here for the definition of "large text":
+     https://www.w3.org/TR/2008/REC-WCAG20-20081211/#larger-scaledef
+     */
+    case EnhancedLargeText
+    
+    var minimumContrastRatio: CGFloat {
+      switch self {
+      case .Standard:
+        return 4.5
+      case .StandardLargeText:
+        return 3
+      case .Enhanced:
+        return 7
+      case .EnhancedLargeText:
+        return 4.5
+      }
+    }
+  }
+  
+  /**
+   Indicates if two colors are contrasting, regarding W3C's WCAG 2.0 recommendations.
+   
+   You can read it here: https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-contrast
+   
+   The acceptable contrast ratio depends on the context of display. Most of the time, the default context (.Standard) is enough.
+   
+   You can look at ContrastDisplayContext for more options.
+   
+   - parameter otherColor: The other color to compare with.
+   - parameter context: An optional context to determine the minimum acceptable contrast ratio. Default value is .Standard.
+   
+   - returns: true is the contrast ratio between 2 colors exceed the minimum acceptable ratio.
+   */
+  func isContrasting(whith otherColor:DynamicColor, inContext context:ContrastDisplayContext = .Standard ) -> Bool {
+    return self.contrastRatio(with: otherColor) > context.minimumContrastRatio
   }
 }

--- a/Tests/DynamicColorTests.swift
+++ b/Tests/DynamicColorTests.swift
@@ -431,4 +431,32 @@ class DynamicColorTests: XCTestCase {
     XCTAssertEqualWithAccuracy(color1.contrastRatio(with: color3), 1.4593100, accuracy: TestsAcceptedAccuracy)
         
   }
+  
+  func testIsContrasting()  {
+    
+    XCTAssertFalse(DynamicColor.black.isContrasting(whith: DynamicColor.black), "A color cannot contrast with itself")
+
+    XCTAssertTrue(DynamicColor.black.isContrasting(whith: DynamicColor.white), "Black and white are always contrasting")
+    
+    XCTAssertTrue(DynamicColor.black.isContrasting(whith: DynamicColor.white, inContext: .Standard), "Black and white are always contrasting")
+    XCTAssertTrue(DynamicColor.black.isContrasting(whith: DynamicColor.white, inContext: .StandardLargeText), "Black and white are always contrasting")
+    XCTAssertTrue(DynamicColor.black.isContrasting(whith: DynamicColor.white, inContext: .Enhanced), "Black and white are always contrasting")
+    XCTAssertTrue(DynamicColor.black.isContrasting(whith: DynamicColor.white, inContext: .EnhancedLargeText), "Black and white are always contrasting")
+
+    // Contrast ratio between white and red = 4. So, we should only return true in StandardLargeText
+    XCTAssertFalse(DynamicColor.white.isContrasting(whith: DynamicColor.red), "White and red are only contrasting in StandardLargeText")
+    XCTAssertFalse(DynamicColor.white.isContrasting(whith: DynamicColor.red, inContext: .Standard), "White and red are only contrasting in StandardLargeText")
+    XCTAssertTrue(DynamicColor.white.isContrasting(whith: DynamicColor.red, inContext: .StandardLargeText), "White and red are only contrasting in StandardLargeText")
+    XCTAssertFalse(DynamicColor.white.isContrasting(whith: DynamicColor.red, inContext: .Enhanced), "White and red are only contrasting in StandardLargeText")
+    XCTAssertFalse(DynamicColor.white.isContrasting(whith: DynamicColor.red, inContext: .EnhancedLargeText), "White and red are only contrasting in StandardLargeText")
+    
+    
+    let pink =  DynamicColor(hexString: "FF00FF")
+    // Contrast ration between FF00FF and black = 6.7, . So, we should only return false in Enhanced
+    XCTAssertTrue(DynamicColor.black.isContrasting(whith: pink), "Black and pink are always contrasting except in Enhanced")
+    XCTAssertTrue(DynamicColor.black.isContrasting(whith: pink, inContext: .Standard), "Black and pink are always contrasting except in Enhanced")
+    XCTAssertTrue(DynamicColor.black.isContrasting(whith: pink, inContext: .StandardLargeText), "Black and pink are always contrasting except in Enhanced")
+    XCTAssertFalse(DynamicColor.black.isContrasting(whith: pink, inContext: .Enhanced), "Black and pink are always contrasting except in Enhanced")
+    XCTAssertTrue(DynamicColor.black.isContrasting(whith: pink, inContext: .EnhancedLargeText), "Black and pink are always contrasting except in Enhanced")
+  }
 }


### PR DESCRIPTION
Hey, 

This PR should solve #22. 

There are multiple ways to use this method. The simple one:  ```
DynamicColor.white.isContrasting(whith: DynamicColor.red) // returns false ```

Or, if you want to be more specific regarding the context:  ```
DynamicColor.white.isContrasting(whith: DynamicColor.red, inContext: .StandardLargeText)  // returns true ```

Indeed, the minimum acceptable ratio is depending on the context (in this case: red on white is only readable if we use large text).