### PR TITLE
Fix imprecision when outputing hex values

### DIFF
--- a/Sources/DynamicColor.swift
+++ b/Sources/DynamicColor.swift
@@ -107,7 +107,7 @@ public extension DynamicColor {
    */
   public final func toHex() -> UInt32 {
     func roundToHex(_ x: CGFloat) -> UInt32 {
-		return UInt32(roundf(Float(x) * 255.0))
+      return UInt32(roundf(Float(x) * 255.0))
     }
 
     let rgba       = toRGBAComponents()

--- a/Sources/DynamicColor.swift
+++ b/Sources/DynamicColor.swift
@@ -107,7 +107,7 @@ public extension DynamicColor {
    */
   public final func toHex() -> UInt32 {
     func roundToHex(_ x: CGFloat) -> UInt32 {
-      return UInt32(round(1000 * x) / 1000 * 255)
+		return UInt32(roundf(Float(x) * 255.0))
     }
 
     let rgba       = toRGBAComponents()

--- a/Tests/DynamicColorTests.swift
+++ b/Tests/DynamicColorTests.swift
@@ -75,6 +75,15 @@ class DynamicColorTests: XCTestCase {
     XCTAssert(black.toHex() == 0x000000, "Color string should be equal to 0x000000")
     XCTAssert(custom.toHex() == 0x769a2b, "Color string should be equal to 0x769a2b")
   }
+	
+  func testHexPrecision() {
+	let allHexes: CountableRange<UInt32> = 0..<0xFFFFFF
+	let impreciseConversions = allHexes.filter({ hex in
+		DynamicColor(hex: hex).toHex() != hex
+	})
+	
+	XCTAssert(impreciseConversions.count == 0, "Imprecise hex convertions on: \(impreciseConversions)")
+  }
 
   func testIsEqualToHexString() {
     let red    = DynamicColor.red
@@ -115,9 +124,9 @@ class DynamicColorTests: XCTestCase {
     let same1   = DynamicColor(hex: 0xc0392b).adjustedHue(amount: 0)
     let same2   = DynamicColor(hex: 0xc0392b).adjustedHue(amount: 360)
 
-    XCTAssert(custom1.isEqual(toHexString: "#876a11"), "Should be equal to #876a11 (not \(custom1.toHexString()))")
-    XCTAssert(custom2.isEqual(toHexString: "#67c02b"), "Should be equal to #67c02b (not \(custom2.toHexString()))")
-    XCTAssert(custom3.isEqual(toHexString: "#c02bb1"), "Should be equal to #c02bb1 (not \(custom3.toHexString()))")
+    XCTAssert(custom1.isEqual(toHexString: "#886a11"), "Should be equal to #876a11 (not \(custom1.toHexString()))")
+    XCTAssert(custom2.isEqual(toHexString: "#68c02b"), "Should be equal to #67c02b (not \(custom2.toHexString()))")
+    XCTAssert(custom3.isEqual(toHexString: "#c02bb2"), "Should be equal to #c02bb1 (not \(custom3.toHexString()))")
     XCTAssert(same1.isEqual(toHexString: "#c0392b"), "Should be equal to #c0392b (not \(same1.toHexString()))")
     XCTAssert(same2.isEqual(toHexString: "#c0392b"), "Should be equal to #c0392b (not \(same2.toHexString()))")
   }
@@ -189,7 +198,7 @@ class DynamicColorTests: XCTestCase {
     XCTAssert(primary.isEqual(toHexString: "#ff0000"), "Color string should be equal to #ff0000 (not \(primary.toHexString()))")
     XCTAssert(white.isEqual(toHexString: "#ffffff"), "Color string should be equal to #ffffff (not \(white.toHexString()))")
     XCTAssert(black.isEqual(toHexString: "#000000"), "Color string should be equal to #000000 (not \(black.toHexString()))")
-    XCTAssert(custom.isEqual(toHexString: "#d72513"), "Color string should be equal to #d72513 (not \(custom.toHexString()))")
+    XCTAssert(custom.isEqual(toHexString: "#d82614"), "Color string should be equal to #d72513 (not \(custom.toHexString()))")
   }
 
   func testSaturateColor() {
@@ -206,10 +215,10 @@ class DynamicColorTests: XCTestCase {
     let black   = DynamicColor.black.desaturated()
     let custom  = DynamicColor(hex: 0xc0392b).desaturated()
 
-    XCTAssert(primary.isEqual(toHexString: "#e51919"), "Color string should be equal to #e51919 (not \(primary.toHexString()))")
+    XCTAssert(primary.isEqual(toHexString: "#e61a1a"), "Color string should be equal to #e51919 (not \(primary.toHexString()))")
     XCTAssert(white.isEqual(toHexString: "#ffffff"), "Color string should be equal to #ffffff (not \(white.toHexString()))")
     XCTAssert(black.isEqual(toHexString: "#000000"), "Color string should be equal to #000000 (not \(black.toHexString()))")
-    XCTAssert(custom.isEqual(toHexString: "#a84b42"), "Color string should be equal to #a84b42 (not \(custom.toHexString()))")
+    XCTAssert(custom.isEqual(toHexString: "#a94c43"), "Color string should be equal to #a84b42 (not \(custom.toHexString()))")
   }
 
   func testDesaturateColor() {
@@ -217,7 +226,7 @@ class DynamicColorTests: XCTestCase {
     let maxi = DynamicColor(hex: 0xc0392b).desaturated(amount: 1)
 
     XCTAssert(same.isEqual(toHexString: "#c0392b"), "Color string should be equal to #c0392b (not \(same.toHexString()))")
-    XCTAssert(maxi.isEqual(toHexString: "#757575"), "Color string should be equal to #757575 (not \(maxi.toHexString()))")
+    XCTAssert(maxi.isEqual(toHexString: "#767676"), "Color string should be equal to #757575 (not \(maxi.toHexString()))")
   }
 
   func testGrayscaleColor() {
@@ -256,11 +265,11 @@ class DynamicColorTests: XCTestCase {
 
     var midMix = red.mixed(withColor: blue)
 
-    XCTAssert(midMix.isEqual(toHexString: "#7f007f"), "Color string should be equal to #7f007f (not \(midMix.toHexString()))")
+    XCTAssert(midMix.isEqual(toHexString: "#800080"), "Color string should be equal to #7f007f (not \(midMix.toHexString()))")
 
     midMix = blue.mixed(withColor: red)
 
-    XCTAssert(midMix.isEqual(toHexString: "#7f007f"), "Color string should be equal to #7f007f")
+    XCTAssert(midMix.isEqual(toHexString: "#800080"), "Color string should be equal to #7f007f (not \(midMix.toHexString())")
 
     let sameMix = green.mixed(withColor: green)
 
@@ -286,11 +295,11 @@ class DynamicColorTests: XCTestCase {
 
     var midMix = red.mixed(withColor: blue, inColorSpace: .lab)
 
-    XCTAssert(midMix.isEqual(toHexString: "#c93a88"), "Color string should be equal to #c93a88")
+    XCTAssert(midMix.isEqual(toHexString: "#c93b88"), "Color string should be equal to #c93a88 (not \(midMix.toHexString()))")
 
     midMix = blue.mixed(withColor: red, inColorSpace: .lab)
 
-    XCTAssert(midMix.isEqual(toHexString: "#c93a88"), "Color string should be equal to #c93a88 (not \(midMix.toHexString()))")
+    XCTAssert(midMix.isEqual(toHexString: "#c93b88"), "Color string should be equal to #c93a88 (not \(midMix.toHexString()))")
 
     let sameMix = green.mixed(withColor: green, inColorSpace: .lab)
 
@@ -315,11 +324,9 @@ class DynamicColorTests: XCTestCase {
     let green = DynamicColor.green
 
     var midMix = red.mixed(withColor: blue, inColorSpace: .hsl)
-
     XCTAssert(midMix.isEqual(toHexString: "#ff00ff"), "Color string should be equal to #ff00ff (not \(midMix.toHexString()))")
 
     midMix = blue.mixed(withColor: red, inColorSpace: .hsl)
-
     XCTAssert(midMix.isEqual(toHexString: "#ff00ff"), "Color string should be equal to #ff00ff")
 
     let sameMix = green.mixed(withColor: green, inColorSpace: .hsl)
@@ -372,7 +379,7 @@ class DynamicColorTests: XCTestCase {
   func testTintColor() {
     let tint = DynamicColor(hex: 0xc0392b).tinted()
 
-    XCTAssert(tint.isEqual(toHexString: "#cc6055"), "Color string should be equal to #cc6055")
+    XCTAssert(tint.isEqual(toHexString: "#cd6155"), "Color string should be equal to #cc6055 (not \(tint.toHexString())")
 
     let white = DynamicColor(hex: 0xc0392b).tinted(amount: 1)
 
@@ -386,7 +393,7 @@ class DynamicColorTests: XCTestCase {
   func testShadeColor() {
     let shade = DynamicColor(hex: 0xc0392b).shaded()
 
-    XCTAssert(shade.isEqual(toHexString: "#992d22"), "Color string should be equal to #992d22")
+    XCTAssert(shade.isEqual(toHexString: "#9a2e22"), "Color string should be equal to #992d22 (not \(shade.toHexString())")
 
     let black = DynamicColor(hex: 0xc0392b).shaded(amount: 1)
 

--- a/Tests/DynamicGradientTests.swift
+++ b/Tests/DynamicGradientTests.swift
@@ -50,6 +50,6 @@ class DynamicGradientTests: XCTestCase {
 
     let darkYellow = [.red, .green].gradient.pickColorAt(scale: 0.5)
 
-    XCTAssert(darkYellow.toHex() == 0x7f7f00, "Color should be a dark yellow (not \(darkYellow.toHexString()))")
+    XCTAssert(darkYellow.toHex() == 0x808000, "Color should be a dark yellow (not \(darkYellow.toHexString()))")
   }
 }


### PR DESCRIPTION
The rounding function to transform `CGFloat` components to `UInt32` was imprecise, causing conversions back and forth to return different values.