### PR TITLE
Fixes a crash when UIColor returns a color component with negative value

### DIFF
--- a/Sources/DynamicColor.swift
+++ b/Sources/DynamicColor.swift
@@ -110,10 +110,7 @@ public extension DynamicColor {
    */
   public final func toHex() -> UInt32 {
     func roundToHex(_ x: CGFloat) -> UInt32 {
-      if x < 0 {
-        return UInt32(0)
-      }
-
+      guard x > 0 else { return 0 }
       let rounded: CGFloat = round(x * 255)
 
       return UInt32(rounded)

--- a/Sources/DynamicColor.swift
+++ b/Sources/DynamicColor.swift
@@ -110,6 +110,10 @@ public extension DynamicColor {
    */
   public final func toHex() -> UInt32 {
     func roundToHex(_ x: CGFloat) -> UInt32 {
+      if x < 0 {
+        return UInt32(0)
+      }
+
       let rounded: CGFloat = round(x * 255)
 
       return UInt32(rounded)


### PR DESCRIPTION
I was getting this crash on my iPhone 7 test device because UIColor was returning a color component with a negative value (-0.005)