### PR TITLE
Fixes crash on iPhone 5

### DIFF
--- a/Sources/DynamicColor.swift
+++ b/Sources/DynamicColor.swift
@@ -79,12 +79,12 @@ public extension DynamicColor {
    - parameter alphaChannel: If true the given hex-decimal UInt32 includes the alpha channel (e.g. 0xFF0000FF).
    */
   public convenience init(hex: UInt32, useAlpha alphaChannel: Bool = false) {
-    let mask = 0xFF
+    let mask = UInt32(0xFF)
 
-    let r = Int(hex >> (alphaChannel ? 24 : 16)) & mask
-    let g = Int(hex >> (alphaChannel ? 16 : 8)) & mask
-    let b = Int(hex >> (alphaChannel ? 8 : 0)) & mask
-    let a = alphaChannel ? Int(hex) & mask : 255
+    let r = hex >> (alphaChannel ? 24 : 16) & mask
+    let g = hex >> (alphaChannel ? 16 : 8) & mask
+    let b = hex >> (alphaChannel ? 8 : 0) & mask
+    let a = alphaChannel ? hex & mask : 255
 
     let red   = CGFloat(r) / 255
     let green = CGFloat(g) / 255


### PR DESCRIPTION
I had this crash on iPhone 5 (and probably on other 32bit devices):

When I called this method with the value `4290756543` or `rgb = (r = 0.75, g = 0.75, b = 0.75, a = 1)` it crashed saying `Not enough bits to represent a signed value` on line 86.

This fixes it, but please review my code to warn me if there's any mistake