### PR TITLE
Update SPM syntax with 4.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ let package = Package(
     name: "YOUR_PROJECT_NAME",
     targets: [],
     dependencies: [
-        .Package(url: "https://github.com/yannickl/DynamicColor.git", versions: "4.2.0" ..< Version.max)
+        .package(url: "https://github.com/yannickl/DynamicColor.git", from: "4.2.1")    
     ]
 )
 ```


### PR DESCRIPTION
# Summary
The syntax for installing the package via Swift Package Manager has changed since `README.md` was created. This PR is to update the syntax along with the latest release version number* `"4.2.1"`.

\* as of Wednesday, 2 October 2019
